### PR TITLE
Configure and enable huey task runner

### DIFF
--- a/roles/karrot-backend/handlers/main.yml
+++ b/roles/karrot-backend/handlers/main.yml
@@ -13,3 +13,10 @@
     name: "{{ site }}-worker.target"
     state: restarted
     daemon_reload: yes
+
+- name: restart huey
+  listen: restart app
+  systemd:
+    name: "{{ site }}-huey.service"
+    state: restarted
+    daemon_reload: yes

--- a/roles/karrot-backend/tasks/main.yml
+++ b/roles/karrot-backend/tasks/main.yml
@@ -187,6 +187,13 @@
   notify:
     - restart workers
 
+- name: systemd huey service
+  template:
+    src: systemd.huey.service.j2
+    dest: /etc/systemd/system/{{ site }}-huey.service
+  notify:
+    - restart huey
+
 - name: systemd enable daphne
   systemd:
     name: "{{ site }}-daphne.service"
@@ -198,6 +205,13 @@
     name: "{{ site }}-worker.target"
     state: started
     enabled: yes
+
+- name: systemd enable huey
+  systemd:
+    name: "{{ site }}-huey.service"
+    state: started
+    enabled: yes
+
 
 #------------------------------------------------------------------
 # deploy setup

--- a/roles/karrot-backend/templates/local_settings.py.j2
+++ b/roles/karrot-backend/templates/local_settings.py.j2
@@ -138,10 +138,6 @@ LOGGING = {
 
     },
     'loggers': {
-        'root': {
-            'level': 'ERROR',
-            'handlers': ['sentry'],
-        },
         'raven': {
             'level': 'WARNING',
             'handlers': ['console'],
@@ -155,6 +151,10 @@ LOGGING = {
         'django': { # Disable django admin email logging by overriding
             'level': 'ERROR',
             'handlers': ['sentry'],
-        }
+        },
+    },
+    'root': { # log everything unconfigured as error
+        'level': 'ERROR',
+        'handlers': ['sentry'],
     },
 }

--- a/roles/karrot-backend/templates/local_settings.py.j2
+++ b/roles/karrot-backend/templates/local_settings.py.j2
@@ -108,7 +108,7 @@ CHANNEL_LAYERS = {
 HUEY = {
     "always_eager": False,
     "connection": {
-        "url": "redis://{}:6739/{{ redis_db }}".format(REDIS_HOST),
+        "url": "redis://{}:6379/{{ redis_db }}".format(REDIS_HOST),
     },
     "consumer": {
         "workers": 4,

--- a/roles/karrot-backend/templates/local_settings.py.j2
+++ b/roles/karrot-backend/templates/local_settings.py.j2
@@ -115,3 +115,46 @@ HUEY = {
         "worker_type" : "greenlet",
     },
 }
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'verbose': {
+            'format': '%(levelname)s %(asctime)s %(module)s '
+                      '%(process)d %(thread)d %(message)s'
+        },
+    },
+    'handlers': {
+        'sentry': {
+            'level': 'WARNING',
+            'class': 'raven.contrib.django.raven_compat.handlers.SentryHandler',
+        },
+        'console': {
+            'level': 'WARNING',
+            'class': 'logging.StreamHandler',
+            'formatter': 'verbose'
+        }
+
+    },
+    'loggers': {
+        'root': {
+            'level': 'ERROR',
+            'handlers': ['sentry'],
+        },
+        'raven': {
+            'level': 'WARNING',
+            'handlers': ['console'],
+            'propagate': False,
+        },
+        'sentry.errors': {
+            'level': 'WARNING',
+            'handlers': ['console'],
+            'propagate': False,
+        },
+        'django': { # Disable django admin email logging by overriding
+            'level': 'ERROR',
+            'handlers': ['sentry'],
+        }
+    },
+}

--- a/roles/karrot-backend/templates/local_settings.py.j2
+++ b/roles/karrot-backend/templates/local_settings.py.j2
@@ -104,3 +104,14 @@ CHANNEL_LAYERS = {
         "ROUTING": "foodsaving.subscriptions.routing.channel_routing",
     },
 }
+
+HUEY = {
+    "always_eager": False,
+    "connection": {
+        "url": "redis://{}:6739/{{ redis_db }}".format(REDIS_HOST),
+    },
+    "consumer": {
+        "workers": 4,
+        "worker_type" : "greenlet",
+    },
+}


### PR DESCRIPTION
This adds a part of settings to local_settings.py to configure huey using the dedicated redis database.

Also, it creates and enables systemd service files to run the huey part of the application.